### PR TITLE
Add compatibility with time 1.5 and use parseTimeM

### DIFF
--- a/feed.cabal
+++ b/feed.cabal
@@ -46,6 +46,5 @@ library
                      old-locale >= 1,
                      old-time   >= 1,
                      xml >= 1.2.6,
-                     utf8-string,
+                     utf8-string < 1,
                      time
-


### PR DESCRIPTION
Hi,

feed does not build with ghc-7.10 due to a change of the API in time >= 1.5.

I added a CPP macro to allow building your package on newer versions >= 7.10 as well.

Cheers,
Markus
