### PR TITLE
Fix dependency on utf8-string

### DIFF
--- a/feed.cabal
+++ b/feed.cabal
@@ -46,6 +46,6 @@ library
                      old-locale >= 1,
                      old-time   >= 1,
                      xml >= 1.2.6,
-                     utf8-string,
+                     utf8-string <= 0.3.8,
                      time
 


### PR DESCRIPTION
The dependency currently fails with "Could not find module `System.IO.UTF8'" as the latest version of utf8-string do not longer expose this module.

Adding an upper bound to the dependency will the problem until the the code can be adapted to account for the API of newer version of utf8-string
