### PR TITLE
Stable utf8 lib, fix pattern match warning

### DIFF
--- a/Text/Feed/Constructor.hs
+++ b/Text/Feed/Constructor.hs
@@ -134,7 +134,9 @@ withFeedItems is fe =
       Feed.Types.RSSFeed  f -> Feed.Types.RSSFeed
           f{rssChannel=(rssChannel f){rssItems=[]}}
       Feed.Types.RSS1Feed f -> Feed.Types.RSS1Feed
-          f{feedItems=[]})
+          f{feedItems=[]}
+      Feed.Types.XMLFeed xml -> Feed.Types.XMLFeed
+          xml{elContent=[]})
    is
 
 newItem :: FeedKind -> Feed.Types.Item

--- a/feed.cabal
+++ b/feed.cabal
@@ -1,5 +1,5 @@
 Name:               feed
-Version:            0.3.9.2
+Version:            0.3.9.3
 License:            BSD3
 License-file:       LICENSE
 Category:           Text
@@ -46,6 +46,5 @@ library
                      old-locale >= 1,
                      old-time   >= 1,
                      xml >= 1.2.6,
-                     utf8-string,
+                     utf8-string == 0.3,
                      time
-


### PR DESCRIPTION
Apparently UTF8 [no longer has the IO module](https://stackoverflow.com/questions/28110769/system-io-utf8-not-found-installing-purescript), so we need to lock into a version that does.

I'm not sure if the pattern match fix is ideal, since I'm still very new to RSS/XML in general, but I try to preserve the spirit of "empty the feed". On the other hand, given `addItem` appears to fail on an XMLFeed, maybe this isn't even necessary at all.
